### PR TITLE
executing journalctl as sudo to prevent permission errors

### DIFF
--- a/.config/scripts/sysmaintenance.sh
+++ b/.config/scripts/sysmaintenance.sh
@@ -46,5 +46,5 @@ echo "----------------------------------------------------"
 echo "CLEARING SYSTEM LOGS"
 echo "----------------------------------------------------"
 
-journalctl --vacuum-time=7d
+sudo journalctl --vacuum-time=7d
 echo ""


### PR DESCRIPTION
i figured out what caused the issues. It has to do with not being able to delete archived journals due to permissions. Elevating them fixes the issue.