### PR TITLE
Modifications to sysmaintenance for safety, stability, and versatility (and supports both yay and paru)

### DIFF
--- a/.config/scripts/sysmaintenance.sh
+++ b/.config/scripts/sysmaintenance.sh
@@ -1,50 +1,119 @@
-# References: Fernando Cejas (https://fernandocejas.com/blog/engineering/2022-03-30-arch-linux-system-maintance/)
-echo "----------------------------------------------------"
-echo "UPDATING SYSTEM"
-echo "----------------------------------------------------"
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# Arch "Spring‑Clean" Maintenance Script
+# (interactive, abort‑safe, log‑to‑file)
+# ------------------------------------------------------------
+#  • Designed for periodic housekeeping (monthly‑ish)
+#  • Optionally run with --upgrade to include a full system upgrade.
+#  • Automatically detects **paru** or **yay** and uses whichever is found.
+#  • Requires: pacman‑contrib (paccache), pacdiff, plus the detected AUR helper.
+# ------------------------------------------------------------
 
-yay -Syu
+set -euo pipefail
+trap 'echo "[!] Aborted by user"; exit 1' INT TERM
 
-echo ""
-echo "----------------------------------------------------"
-echo "CLEARING PACMAN CACHE"
-echo "----------------------------------------------------"
-
-pacman_cache_space_used="$(du -sh /var/cache/pacman/pkg/)"
-echo "Space currently in use: $pacman_cache_space_used"
-echo ""
-echo "Clearing Cache, leaving newest 2 versions:"
-paccache -vrk2
-echo ""
-echo "Clearing all uninstalled packages:"
-paccache -ruk0
-
-echo ""
-echo "----------------------------------------------------"
-echo "REMOVING ORPHANED PACKAGES"
-echo "----------------------------------------------------"
-
-orphaned=$(yay -Qdtq)
-if [ -n "$orphaned" ]; then
-    echo "$orphaned" | yay -Rns -
+# ---------- Detect AUR helper ---------------------------------------------
+if command -v paru &>/dev/null; then
+  AUR=paru
+elif command -v yay &>/dev/null; then
+  AUR=yay
 else
-    echo "No orphaned packages to remove."
+  echo "Error: neither paru nor yay found in PATH." >&2
+  exit 1
+fi
+# --------------------------------------------------------------------------
+
+# ---------- Config ---------------------------------------------------------
+LOG_DIR="$HOME/.local/var/log"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/spring-clean-$(date +%F_%H-%M-%S).log"
+
+PACCACHE_RETAIN=2   # keep N package versions
+CACHE_DAYS=30       # prune ~/.cache entries older than N days
+JOURNAL_RETAIN="7d" # e.g. 500M or 7d
+# --------------------------------------------------------------------------
+
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# ---------- Helpers --------------------------------------------------------
+confirm() {
+  read -r -p "${1:-Are you sure? [y/N]} " ans
+  [[ "$ans" =~ ^([yY][eE][sS]|[yY])$ ]]
+}
+
+announce() { printf "\n\e[1;34m==> %s\e[0m\n" "$1"; }
+
+# ---------- CLI Switches ---------------------------------------------------
+DO_UPGRADE=false
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -u|--upgrade) DO_UPGRADE=true ; shift ;;
+    -h|--help)
+      echo "Usage: $0 [--upgrade]"
+      exit 0 ;;
+    *) echo "Unknown option: $1" ; exit 2 ;;
+  esac
+done
+
+announce "Arch Spring‑Clean starting $(date)  —  using $AUR"
+
+# ---------- 1. Optional system upgrade ------------------------------------
+if $DO_UPGRADE; then
+  announce "System upgrade ($AUR)"
+  $AUR -Syu --ask 4   # interactive for .pacnew merges
+  echo "Run 'sudo pacdiff' after the script to merge new config files."
 fi
 
-echo ""
-echo "----------------------------------------------------"
-echo "CLEARING HOME CACHE"
-echo "----------------------------------------------------"
+# ---------- 2. Pacman cache trim ------------------------------------------
+announce "Pacman cache trim (keeping latest $PACCACHE_RETAIN)"
+current_cache=$(du -sh /var/cache/pacman/pkg | cut -f1)
+echo "Current cache: $current_cache"
+if confirm "Clean pacman cache now? [y/N]"; then
+  sudo paccache -vrk$PACCACHE_RETAIN
+  sudo paccache -ruk0
+fi
+new_cache=$(du -sh /var/cache/pacman/pkg | cut -f1)
+echo "Cache after trim: $new_cache"
 
-home_cache_used="$(du -sh ~/.cache)"
-rm -rf ~/.cache/
-echo "Clearing ~/.cache/..."
-echo "Spaced saved: $home_cache_used"
+# ---------- 3. Orphaned packages ------------------------------------------
+announce "Removing orphaned packages"
+mapfile -t ORPHANS < <($AUR -Qtdq)
+if ((${#ORPHANS[@]})); then
+  printf "Found %d orphan(s):\n%s\n" "${#ORPHANS[@]}" "${ORPHANS[*]}"
+  if confirm "Remove these? [y/N]"; then
+    sudo pacman -Rns "${ORPHANS[@]}"
+  fi
+else
+  echo "No orphans detected."
+fi
 
-echo ""
-echo "----------------------------------------------------"
-echo "CLEARING SYSTEM LOGS"
-echo "----------------------------------------------------"
+# ---------- 4. $HOME/.cache prune ----------------------------------------
+announce "Pruning ~/.cache (unused > $CACHE_DAYS days)"
+cache_before=$(du -sh ~/.cache | cut -f1)
+echo "Before: $cache_before"
+if confirm "Clean ~/.cache now? [y/N]"; then
+  find ~/.cache -type f -mtime +$CACHE_DAYS -print -delete
+  find ~/.cache -type d -empty -print -delete
+fi
+cache_after=$(du -sh ~/.cache | cut -f1)
+echo "After: $cache_after"
 
-sudo journalctl --vacuum-time=7d
-echo ""
+# ---------- 5. Journald rotate & vacuum ----------------------------------
+announce "Vacuuming journald logs ($JOURNAL_RETAIN)"
+journal_before=$(journalctl --disk-usage | awk '{print $NF}')
+if confirm "Rotate & vacuum journald now? [y/N]"; then
+  sudo journalctl --rotate
+  sudo journalctl --vacuum-time=$JOURNAL_RETAIN
+fi
+journal_after=$(journalctl --disk-usage | awk '{print $NF}')
+echo "Journald: $journal_before  ->  $journal_after"
+
+# ---------- 6. Failed systemd units --------------------------------------
+announce "Scanning for failed systemd services"
+if systemctl --failed --quiet; then
+  echo "No failed units detected."
+else
+  systemctl --failed --no-pager --plain
+fi
+
+announce "Spring‑Clean finished in ${SECONDS}s — log saved to $LOG_FILE"


### PR DESCRIPTION
I really like the sysmaintenance script, but I had some slight concerns and additional needs so I modified it a bit. 

1. Added option for either yay or paru (since others may find and use this like I did and I run each on different machines)
2. Added set -euo pipefail to ensure fail early if there are issues. Also trap. Abort safe.
3. Safer cache cleaning
4. Better orphan package handling
5. Added a failed systemd service check because this sort of cleanup is the perfect time to check for that as well and address.
6. Added more user confirmation and more output to know what's happening
7. Added logging so that you can refer back if anything goes wrong (or right or just to be able to audit)
8. And finally, added an --upgrade flag so the script is focused on cleanup, but you can optionally do the update/upgrade. Presumes you're not just doing upgrades once a month or however frequently you run the script, but update more frequently, making that less important at time of running the script.

Apologies if this is overstep. I just made these mods for myself and figured it might be useful if fed back upstream.